### PR TITLE
Set 'searchBarOriginY' to 0

### DIFF
--- a/KFXLog/Classes/View Controllers/KFXLogFileDetailVC.m
+++ b/KFXLog/Classes/View Controllers/KFXLogFileDetailVC.m
@@ -181,18 +181,10 @@
                                 @"prevButton":self.previousResultButton,
                                 @"nextButton":self.nextResultButton
                                 };
-    CGFloat searchBarOriginY = 0.0;
-    if (self.navigationController.navigationBar != nil) {
-        searchBarOriginY += self.navigationController.navigationBar.bounds.size.height;
-    }
-    if (![UIApplication sharedApplication].isStatusBarHidden) {
-        searchBarOriginY += 20.0;
-    }
     NSDictionary *metrics = @{
-                              @"searchBarY":@(searchBarOriginY),
+                              @"searchBarY":@(0),
                               @"labelHeight":@(30)
                               };
-    
     // ## Horizontal ##
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[searchBar]|"
                                                                       options:kNilOptions
@@ -237,24 +229,6 @@
                                                                       metrics:nil
                                                                         views:viewsDict]];
 }
-
--(void)updateViewConstraints{
-
-    /*
-     Update the constraint for the search bar origin Y based on if there is a status bar and navigation bar visible - keep search bar flush to the top subview
-    */
-    CGFloat searchBarOriginY = 0.0;
-    if (self.navigationController.navigationBar != nil) {
-        searchBarOriginY += self.navigationController.navigationBar.bounds.size.height;
-    }
-    if (![UIApplication sharedApplication].isStatusBarHidden) {
-        searchBarOriginY += 20.0;
-    }
-    self.searchBarOriginY.constant = searchBarOriginY;
-    
-    [super updateViewConstraints];
-}
-
 
 
 //--------------------------------------------------------
@@ -358,20 +332,18 @@
     }
 }
 
--(void)scrollTextViewToTextInRange:(NSRange)range{
+- (void)scrollTextViewToTextInRange:(NSRange)range {
 
     [self.textView setSelectedRange:range];
     
     CGRect textRect = [self.textView firstRectForRange:self.textView.selectedTextRange];
-    [KFXLog logInfo:@"TextRect: %@",NSStringFromCGRect(textRect)];
     if (!CGRectContainsRect(self.textView.bounds, textRect)) {
         [self.textView scrollRectToVisible:textRect
                                   animated:YES];
-
     }
     
     [self.textView setSelectedRange:NSMakeRange(0, 0)];
-    }
+}
 
 //======================================================
 #pragma mark - ** Protocol Methods **

--- a/KFXLog/Classes/View Controllers/KFXLogFileDetailVC.m
+++ b/KFXLog/Classes/View Controllers/KFXLogFileDetailVC.m
@@ -210,7 +210,7 @@
                                                             toItem:self.view
                                                          attribute:NSLayoutAttributeTop
                                                         multiplier:1.0
-                                                          constant:searchBarOriginY];
+                                                          constant:0];
     [self.view addConstraint:self.searchBarOriginY];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[searchBar(50)][resultBar(45)][textView]|"
                                                                       options:kNilOptions


### PR DESCRIPTION
Hey, sooooory for the big delay. I've created this PR to fix a bug that was setting the Y offset of the search bar in `KFXLogFileDetailVC`. Before, the Y offset was set to ±60 and it would be placed lower than expected.

<img src="https://user-images.githubusercontent.com/3796970/59913845-b0a5d380-9421-11e9-9b81-eb53eff1834a.jpeg" width="250">

After removing the Y offset, it looks like this:

<img src="https://user-images.githubusercontent.com/3796970/59914008-17c38800-9422-11e9-9b66-e5aacbe2e8ca.png" width="250">

Tested on iPhoneXS, iPhone 6 and iPad Air (portrait and landscape) running iOS 9.3 and 12.2